### PR TITLE
Configure Jest to resolve src aliases

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,6 +81,9 @@
     "transform": {
       "^.+\\.(t|j)s$": "ts-jest"
     },
+    "moduleNameMapper": {
+      "^src/(.*)$": "<rootDir>/$1"
+    },
     "collectCoverageFrom": [
       "**/*.(t|j)s"
     ],


### PR DESCRIPTION
## Summary
- map `src/*` imports to the source root so Jest can locate modules

## Testing
- `npm test` *(fails: FilesService should be defined, FilesController should be defined, UsersService should be defined, FoldersService should be defined, AuthController should be defined, FoldersController should be defined)*

------
https://chatgpt.com/codex/tasks/task_e_68a283c9bc688324bb8ec85b299579b5