### PR TITLE
Specify cron job name to avoid crypto usage

### DIFF
--- a/src/files/file-url-refresh.service.ts
+++ b/src/files/file-url-refresh.service.ts
@@ -8,7 +8,9 @@ export class FileUrlRefreshService {
 
   constructor(private readonly filesService: FilesService) {}
 
-  @Cron(CronExpression.EVERY_HOUR)
+  // Provide an explicit name so the scheduler doesn't rely on a global `crypto`.
+  // This prevents runtime errors in environments where the `crypto` global is absent.
+  @Cron(CronExpression.EVERY_HOUR, { name: 'file-url-refresh' })
   async refreshUrls() {
     const updated = await this.filesService.refreshDiscordUrls();
     this.logger.log(`Refreshed URLs for ${updated} files`);


### PR DESCRIPTION
## Summary
- name the hourly URL refresh cron job to avoid reliance on global `crypto`

## Testing
- `npm test` *(fails: Nest can't resolve dependencies)*
- `npm start`


------
https://chatgpt.com/codex/tasks/task_e_68a2fceb2a308324b98627e04617465e