### PR TITLE
Refresh user file URLs on login

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -10,7 +10,6 @@ import { FoldersModule } from './folders/folders.module';
 import { FilesModule } from './files/files.module';
 import { CatModule } from './cat/cat.module';
 import { ConfigModule } from '@nestjs/config';
-import { ScheduleModule } from '@nestjs/schedule';
 
 @Module({
   imports: [
@@ -21,7 +20,6 @@ import { ScheduleModule } from '@nestjs/schedule';
     MongooseModule.forRoot(
       process.env.MONGODB_URI || 'mongodb://localhost:27017/images-storage',
     ),
-    ScheduleModule.forRoot(),
     AuthModule,
     UsersModule,
     FoldersModule,

--- a/src/auth/auth.controller.spec.ts
+++ b/src/auth/auth.controller.spec.ts
@@ -1,5 +1,6 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { AuthController } from './auth.controller';
+import { AuthService } from './auth.service';
 
 describe('AuthController', () => {
   let controller: AuthController;
@@ -7,6 +8,15 @@ describe('AuthController', () => {
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       controllers: [AuthController],
+      providers: [
+        {
+          provide: AuthService,
+          useValue: {
+            signIn: jest.fn(),
+            register: jest.fn(),
+          },
+        },
+      ],
     }).compile();
 
     controller = module.get<AuthController>(AuthController);

--- a/src/auth/auth.module.ts
+++ b/src/auth/auth.module.ts
@@ -4,10 +4,12 @@ import { AuthService } from './auth.service';
 import { UsersModule } from 'src/users/users.module';
 import { jwtConstants } from './constants';
 import { JwtModule } from '@nestjs/jwt/dist/jwt.module';
+import { FilesModule } from 'src/files/files.module';
 
 @Module({
   imports: [
     UsersModule,
+    FilesModule,
     JwtModule.register({
       global: true,
       secret: jwtConstants.secret,

--- a/src/auth/auth.service.spec.ts
+++ b/src/auth/auth.service.spec.ts
@@ -1,12 +1,23 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { AuthService } from './auth.service';
+import { UsersService } from 'src/users/users.service';
+import { JwtService } from '@nestjs/jwt';
+import { FileUrlRefreshService } from 'src/files/file-url-refresh.service';
 
 describe('AuthService', () => {
   let service: AuthService;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      providers: [AuthService],
+      providers: [
+        AuthService,
+        { provide: UsersService, useValue: {} },
+        { provide: JwtService, useValue: {} },
+        {
+          provide: FileUrlRefreshService,
+          useValue: { refreshUrlsForUser: jest.fn() },
+        },
+      ],
     }).compile();
 
     service = module.get<AuthService>(AuthService);

--- a/src/files/file-url-refresh.service.ts
+++ b/src/files/file-url-refresh.service.ts
@@ -1,5 +1,4 @@
 import { Injectable, Logger } from '@nestjs/common';
-import { Cron, CronExpression } from '@nestjs/schedule';
 import { FilesService } from './files.service';
 
 @Injectable()
@@ -8,11 +7,10 @@ export class FileUrlRefreshService {
 
   constructor(private readonly filesService: FilesService) {}
 
-  // Provide an explicit name so the scheduler doesn't rely on a global `crypto`.
-  // This prevents runtime errors in environments where the `crypto` global is absent.
-  @Cron(CronExpression.EVERY_HOUR, { name: 'file-url-refresh' })
-  async refreshUrls() {
-    const updated = await this.filesService.refreshDiscordUrls();
-    this.logger.log(`Refreshed URLs for ${updated} files`);
+  async refreshUrlsForUser(userId: string) {
+    const updated = await this.filesService.refreshDiscordUrlsForUser(userId);
+    this.logger.log(
+      `Refreshed URLs for ${updated} files of user ${userId}`,
+    );
   }
 }

--- a/src/files/files.controller.spec.ts
+++ b/src/files/files.controller.spec.ts
@@ -1,5 +1,6 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { FilesController } from './files.controller';
+import { FilesService } from './files.service';
 
 describe('FilesController', () => {
   let controller: FilesController;
@@ -7,6 +8,7 @@ describe('FilesController', () => {
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       controllers: [FilesController],
+      providers: [{ provide: FilesService, useValue: {} }],
     }).compile();
 
     controller = module.get<FilesController>(FilesController);

--- a/src/files/files.module.ts
+++ b/src/files/files.module.ts
@@ -12,6 +12,6 @@ import { FileUrlRefreshService } from './file-url-refresh.service';
   ],
   controllers: [FilesController],
   providers: [FilesService, DiscordStorageService, FileUrlRefreshService],
-  exports: [FilesService, DiscordStorageService],
+  exports: [FilesService, DiscordStorageService, FileUrlRefreshService],
 })
 export class FilesModule {}

--- a/src/files/files.service.spec.ts
+++ b/src/files/files.service.spec.ts
@@ -1,12 +1,19 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { FilesService } from './files.service';
+import { getModelToken } from '@nestjs/mongoose';
+import { Files } from './files.schema';
+import { DiscordStorageService } from '../common/services/discord-storage.service';
 
 describe('FilesService', () => {
   let service: FilesService;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      providers: [FilesService],
+      providers: [
+        FilesService,
+        { provide: getModelToken(Files.name), useValue: {} },
+        { provide: DiscordStorageService, useValue: {} },
+      ],
     }).compile();
 
     service = module.get<FilesService>(FilesService);

--- a/src/folders/folders.controller.spec.ts
+++ b/src/folders/folders.controller.spec.ts
@@ -1,5 +1,13 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { FoldersController } from './folders.controller';
+import { FoldersService } from './folders.service';
+import { AuthGuard } from '../common/guards/auth.guard';
+
+class MockAuthGuard {
+  canActivate() {
+    return true;
+    }
+}
 
 describe('FoldersController', () => {
   let controller: FoldersController;
@@ -7,7 +15,11 @@ describe('FoldersController', () => {
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       controllers: [FoldersController],
-    }).compile();
+      providers: [{ provide: FoldersService, useValue: {} }],
+    })
+      .overrideGuard(AuthGuard)
+      .useClass(MockAuthGuard)
+      .compile();
 
     controller = module.get<FoldersController>(FoldersController);
   });

--- a/src/folders/folders.service.spec.ts
+++ b/src/folders/folders.service.spec.ts
@@ -1,12 +1,19 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { FoldersService } from './folders.service';
+import { getModelToken } from '@nestjs/mongoose';
+import { Folders } from './folders.schema';
+import { FilesService } from '../files/files.service';
 
 describe('FoldersService', () => {
   let service: FoldersService;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      providers: [FoldersService],
+      providers: [
+        FoldersService,
+        { provide: getModelToken(Folders.name), useValue: {} },
+        { provide: FilesService, useValue: {} },
+      ],
     }).compile();
 
     service = module.get<FoldersService>(FoldersService);

--- a/src/users/users.service.spec.ts
+++ b/src/users/users.service.spec.ts
@@ -1,12 +1,17 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { UsersService } from './users.service';
+import { getModelToken } from '@nestjs/mongoose';
+import { User } from './users.schema';
 
 describe('UsersService', () => {
   let service: UsersService;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      providers: [UsersService],
+      providers: [
+        UsersService,
+        { provide: getModelToken(User.name), useValue: {} },
+      ],
     }).compile();
 
     service = module.get<UsersService>(UsersService);


### PR DESCRIPTION
## Summary
- refresh discord URLs only for the logging-in user's files
- remove hourly URL refresh cron
- wire file URL refresh service into auth module

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a3052aa4b483248b3c0d0f79bac857