### PR TITLE
feat: allow updating user role

### DIFF
--- a/src/users/users.controller.ts
+++ b/src/users/users.controller.ts
@@ -36,8 +36,15 @@ export class UsersController {
 
   @Patch(':id')
   @Roles(Role.Admin)
-  update(@Param('id') id: string, @Body() user: Partial<User>) {
-    return this.usersService.update(id, user);
+  update(@Param('id') id: string, @Body() body: unknown) {
+    const { role, ...rest } = body as { role?: Role } & Partial<User>;
+    const updateData: Partial<User> = { ...rest };
+
+    if (role) {
+      updateData.roles = [role];
+    }
+
+    return this.usersService.update(id, updateData);
   }
 
   @Delete(':id')

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -21,7 +21,10 @@ export class UsersService {
   }
 
   async update(id: string, user: Partial<User>) {
-    return this.userModel.findByIdAndUpdate(id, user, { new: true });
+    return this.userModel.findByIdAndUpdate(id, user, {
+      new: true,
+      runValidators: true,
+    });
   }
 
   async remove(id: string) {


### PR DESCRIPTION
## Summary
- support updating a single role via `PATCH /users/:id`
- run mongoose validators when modifying users

## Testing
- `npm test`
- `npm run lint` *(fails: Unsafe member access .message on an `any` value, Invalid type "ObjectId" of template literal expression, etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68a4208004908324a8f7d7c3bf491f9c