### PR TITLE
Validate user ID before database operations

### DIFF
--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -1,7 +1,7 @@
-import { Injectable } from '@nestjs/common';
+import { BadRequestException, Injectable } from '@nestjs/common';
 import { InjectModel } from '@nestjs/mongoose';
 import { User } from './users.schema';
-import { Model } from 'mongoose';
+import { Model, isValidObjectId } from 'mongoose';
 
 @Injectable()
 export class UsersService {
@@ -21,6 +21,10 @@ export class UsersService {
   }
 
   async update(id: string, user: Partial<User>) {
+    if (!isValidObjectId(id)) {
+      throw new BadRequestException('Invalid user ID');
+    }
+
     return this.userModel.findByIdAndUpdate(id, user, {
       new: true,
       runValidators: true,
@@ -28,6 +32,10 @@ export class UsersService {
   }
 
   async remove(id: string) {
+    if (!isValidObjectId(id)) {
+      throw new BadRequestException('Invalid user ID');
+    }
+
     return this.userModel.findByIdAndDelete(id);
   }
 }


### PR DESCRIPTION
## Summary
- validate MongoDB ID before updating or deleting users
- return 400 Bad Request for invalid IDs instead of crashing

## Testing
- `npm test`
- `npm run lint` *(fails: Role is defined but never used etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68a45cfb26ec83249bc26cea0a18a884